### PR TITLE
allow administrator to disable token reissuance

### DIFF
--- a/cgi/provisioning.cgi
+++ b/cgi/provisioning.cgi
@@ -151,6 +151,10 @@ def show_reissue_page(config, user):
     sys.stdout.write(out)
     sys.exit(0)
 
+def show_reissue_denied(config):
+    syslog.syslog(syslog.LOG_NOTICE,
+        'Attempt to reissue token when token reissuance disabled')
+    bad_request(config, "The ability to reissue tokens is currently disabled.")
 
 def show_totp_page(config, user, gaus):
     # generate provisioning URI
@@ -283,12 +287,22 @@ def cgimain():
     except totpcgi.UserSecretError, ex:
         bad_request(config, 'Existing secret could not be processed: %s' % ex)
 
+    allow_reissue = config.getboolean('secret', 'allow_reissue')
+
     if exists and action != 'reissue':
         syslog.syslog(syslog.LOG_NOTICE,
             'Secret exists: user=%s, host=%s' % (user, remote_host))
-        show_reissue_page(config, user)
+        # make sure we're allowed to reissue tokens
+        if allow_reissue:
+            show_reissue_page(config, user)
+        else:
+            show_reissue_denied(config)
 
     if action == 'reissue':
+        # make sure we're allowed to reissue
+        if not allow_reissue:
+            show_reissue_denied(config)
+
         # verify token first
         tokencode = form.getfirst('tokencode')
         gau = totpcgi.GAUser(user, backends)

--- a/conf/provisioning.conf
+++ b/conf/provisioning.conf
@@ -52,6 +52,9 @@ templates_dir = /etc/totpcgi/templates
 #
 # Be careful turning this on.
 trust_http_auth = False
+#
+# Allow tokens to be re-issued via provisioning.cgi
+allow_reissue = True
 
 
 [pincode]


### PR DESCRIPTION
In our organization it's desirable to require human intervention prior to re-issuing a token. This patch makes token re-issuance a configurable option that's enabled by default.