### PR TITLE
 Add "issuer" to the generated QRCODE

### DIFF
--- a/cgi/provisioning.cgi
+++ b/cgi/provisioning.cgi
@@ -36,6 +36,11 @@ from StringIO import StringIO
 
 from string import Template
 
+try:
+    from urllib.parse import quote
+except ImportError:
+    from urllib import quote
+
 if len(sys.argv) > 1:
     # blindly assume it's the config file
     config_file = sys.argv[1]
@@ -155,12 +160,16 @@ def show_reissue_page(config, user):
 def show_totp_page(config, user, gaus):
     # generate provisioning URI
     tpt = Template(config.get('secret', 'totp_user_mask'))
+    try:
+        totp_issuer = config.get('secret', 'totp_issuer')
+    except ConfigParser.NoOptionError:
+        totp_issuer = None
     totp_user = tpt.safe_substitute(username=user)
-    totp_qr_uri = gaus.totp.provisioning_uri(totp_user)
+    totp_qr_uri = gaus.totp.provisioning_uri(totp_user, issuer_name=totp_issuer)
 
     action_url = config.get('secret', 'action_url')
     
-    qrcode_embed = '<img src="%s?qrcode=%s"/>' % (action_url, totp_qr_uri)
+    qrcode_embed = '<img src="%s?qrcode=%s"/>' % (action_url, quote(totp_qr_uri))
 
     templates_dir = config.get('secret', 'templates_dir')
     fh = open(os.path.join(templates_dir, 'totp.html'))

--- a/conf/provisioning.conf
+++ b/conf/provisioning.conf
@@ -32,6 +32,9 @@ bits = 80
 # descriptive of your environment.
 totp_user_mask = $username@example.com
 
+# Issuer of the token (e.g. Company Name)
+# totp_issuer = Example Company
+
 # Used by provisioning.cgi
 # Where the provisioning CGI is located, with regards to the web root.
 action_url = /index.cgi
@@ -52,7 +55,6 @@ templates_dir = /etc/totpcgi/templates
 #
 # Be careful turning this on.
 trust_http_auth = False
-
 
 [pincode]
 # Which hashing mechanism to use. Valid entries: md5, bcrypt, sha256, sha512

--- a/conf/provisioning.conf
+++ b/conf/provisioning.conf
@@ -56,6 +56,7 @@ templates_dir = /etc/totpcgi/templates
 # Be careful turning this on.
 trust_http_auth = False
 
+
 [pincode]
 # Which hashing mechanism to use. Valid entries: md5, bcrypt, sha256, sha512
 usehash = sha256

--- a/contrib/totpprov.py
+++ b/contrib/totpprov.py
@@ -199,8 +199,12 @@ def generate_user_token(backends, config, args, pincode=None):
     print 'New token generated for user %s' % user
     # generate provisioning URI
     tpt = Template(config.get('secret', 'totp_user_mask'))
+    try:
+        totp_issuer = config.get('secret', 'totp_issuer')
+    except ConfigParser.NoOptionError:
+        totp_issuer = None
     totp_user = tpt.safe_substitute(username=user)
-    qr_uri = gaus.otp.provisioning_uri(totp_user)
+    qr_uri = gaus.otp.provisioning_uri(totp_user, issuer_name=totp_issuer)
 
     print 'OTP URI: %s' % qr_uri
     if gaus.is_hotp():


### PR DESCRIPTION
Add issuer to generated qrcode. Also, encode the qrcode url passed to the qrcode generation endpoint. This causes issues if the issuer name has any non url friendly chars (e.g. spaces).