### PR TITLE
 Add "issuer" to the generated QRCODE #37

### DIFF
--- a/cgi/provisioning.cgi
+++ b/cgi/provisioning.cgi
@@ -156,7 +156,7 @@ def show_totp_page(config, user, gaus):
     # generate provisioning URI
     tpt = Template(config.get('secret', 'totp_user_mask'))
     totp_user = tpt.safe_substitute(username=user)
-    totp_qr_uri = gaus.totp.provisioning_uri(totp_user)
+    totp_qr_uri = gaus.otp.provisioning_uri(totp_user)
 
     action_url = config.get('secret', 'action_url')
     

--- a/conf/provisioning.conf
+++ b/conf/provisioning.conf
@@ -32,6 +32,9 @@ bits = 80
 # descriptive of your environment.
 totp_user_mask = $username@example.com
 
+# Issuer of the token (e.g. Company Name)
+# totp_issuer = Example Company
+
 # Used by provisioning.cgi
 # Where the provisioning CGI is located, with regards to the web root.
 action_url = /index.cgi

--- a/contrib/totpprov.py
+++ b/contrib/totpprov.py
@@ -199,8 +199,12 @@ def generate_user_token(backends, config, args, pincode=None):
     print 'New token generated for user %s' % user
     # generate provisioning URI
     tpt = Template(config.get('secret', 'totp_user_mask'))
+    try:
+        totp_issuer = config.get('secret', 'totp_issuer')
+    except ConfigParser.NoOptionError:
+        totp_issuer = None
     totp_user = tpt.safe_substitute(username=user)
-    qr_uri = gaus.otp.provisioning_uri(totp_user)
+    qr_uri = gaus.otp.provisioning_uri(totp_user, issuer_name=totp_issuer)
 
     print 'OTP URI: %s' % qr_uri
     if gaus.is_hotp():


### PR DESCRIPTION
Add issuer to generated qrcode. Also, encode the qrcode url passed to the qrcode generation endpoint. This causes issues if the issuer name has any non url friendly chars (e.g. spaces).