### PR TITLE
Remove user from cache when removing from DB

### DIFF
--- a/totpcgi/backends/mysql.py
+++ b/totpcgi/backends/mysql.py
@@ -201,6 +201,9 @@ class GAStateBackend(totpcgi.backends.GAStateBackend):
                 logger.debug('No entries left for user=%s, deleting', user)
                 cur.execute('DELETE FROM users WHERE userid=%s', (userid,))
 
+                # remove from dictionary/cache
+                del userids[user]
+
         self.conn.commit()
 
 

--- a/totpcgi/backends/pgsql.py
+++ b/totpcgi/backends/pgsql.py
@@ -204,6 +204,9 @@ class GAStateBackend(totpcgi.backends.GAStateBackend):
                     # we may not have permissions, so ignore this failure.
                     pass
 
+                # remove from dictionary/cache
+                del userids[user]
+
         self.conn.commit()
 
 


### PR DESCRIPTION
When a user is added because they don't exist and then removed, they
should also be removed from the cache dictionary. If they are not, the
next check will return a non-existent userid from the cache and DB
operations will fail, leaving an aborted transaction until the service
is restarted.